### PR TITLE
Fix VR to FTA rail

### DIFF
--- a/pages/en/developers/third-party-apis/index.md
+++ b/pages/en/developers/third-party-apis/index.md
@@ -4,9 +4,9 @@ order: 1
 ---
 
 
-| Service                                      | Description                | API base url                               |
-|----------------------------------------------|----------------------------|--------------------------------------------|
-| [Alerts Oulu - API](../3rd-party-apis/)      | Oulu disruption info       | http://92.62.36.215:8080/gtfs-rt/service-alerts/
-| [Realtime Oulu - API](../3rd-party-apis/)    | Realtime Oulu API          | http://92.62.36.215:8080/gtfs-rt/trip-updates/
-| [Realtime VR - API](../3rd-party-apis/)      | Realtime VR API            | http://rata.digitraffic.fi/api/v1/
-| [Realtime Tampere - API](../3rd-party-apis/) | Realtime Tampere API       | http://data.itsfactory.fi/journeys/api/1/vehicle-activity/
+| Service                                       | Description                | API base url                               |
+|-----------------------------------------------|----------------------------|--------------------------------------------|
+| [Alerts Oulu - API](../3rd-party-apis/)       | Oulu disruption info       | http://92.62.36.215:8080/gtfs-rt/service-alerts/
+| [Realtime Oulu - API](../3rd-party-apis/)     | Realtime Oulu API          | http://92.62.36.215:8080/gtfs-rt/trip-updates/
+| [Realtime FTA rail - API](../3rd-party-apis/) | Realtime FTA rail API      | http://rata.digitraffic.fi/api/v1/
+| [Realtime Tampere - API](../3rd-party-apis/)  | Realtime Tampere API       | http://data.itsfactory.fi/journeys/api/1/vehicle-activity/


### PR DESCRIPTION
Digitraffic is owned by FTA.